### PR TITLE
Some data from scripts.xchat.cz are still using ISO-8859-2

### DIFF
--- a/list.cc
+++ b/list.cc
@@ -71,6 +71,6 @@ retry:
 
 	sort(listout.begin(), listout.end(), stringcmp);
 	for (listout_t::iterator i = listout.begin(); i != listout.end(); i++)
-	    i->name = recode_utf8_to_client(i->name);
+	    i->name = recode_to_client(i->name);
     }
 }

--- a/userinfo.cc
+++ b/userinfo.cc
@@ -87,7 +87,7 @@ retry1:
 
 	if (!s.getline(l))
 	    throw runtime_error("User info is not complete.");
-	out.icq = recode_utf8_to_client(chomp(l));
+	out.icq = recode_to_client(chomp(l));
 
 	s.close();
 


### PR DESCRIPTION
Some data (room names, user's ICQ) from scripts.xchat.cz are still using ISO-8859-2 encoding, resulting in `Error: An invalid multibyte sequence has been encountered in the input.`

This PR should solve that (at least for /list and /whois).